### PR TITLE
Add ability to use different port in ssh connections

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -134,6 +134,9 @@ function openSSHTerminal(serverName) {
             hasErrors = true;
         }
         var sshCommand = 'ssh ' + server.configuration.host + ' -l ' + server.configuration.username;
+        // Add port if different from default port
+        if (server.configuration.port !== undefined && server.configuration.port && server.configuration.port !== 22)
+            sshCommand += ' -p ' + server.configuration.port;
         var sshAuthorizationMethod = "byPass";
         // Authorization through an agent
         if (server.configuration.agent !== undefined && server.configuration.agent)


### PR DESCRIPTION
Hello,

I've run into a use case where I'm using a different port to connect via SSH. This PR is to add the ability to use a different port when creating the SSH command.

This extension is wonderful, thank you for the hard work. I hope this PR helps.