### PR TITLE
Port Knocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ For example:
             "path": "/",
             "customCommands": [
               "pwd"
-            ]
+            ],
+            "portKnockingPort" : 82517
         },
         ...
     ]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Server object parameters:
 - **project**  _(object)_ - specify local workspace path and server root path for fast terminal open.
 - **path** _(string)_ - used for change directory after server connection.
 - **customCommands** _(array of strings)_ - specifies custom commands which will execute on session start
-- **portKnockingPort** _(number)_ - Port to knock
+- **portKnocking** _(object)_ - Port knocking server details
 
 For example:
 ```json
@@ -90,23 +90,28 @@ For example:
             "customCommands": [
               "pwd"
             ],
-            "portKnockingPort" : 82517
+            "portKnocking" : {
+              "host": "example.com",
+              "port": 82517
+            }
         },
         ...
     ]
 }
 ```
 
-#### sshextension.portKnockingPort
+#### sshextension.portKnocking
 
-  * Type: `Number`
+  * Type: `Object`
   * Defaut: ``
 
-Specifies custom commands which will execute on session start.  
+Specifies server details to be knocked prior to SSH connection. Host will revert to SSH host if undefined. Port is required
 For example:
 ```json
 {
-  "sshextension.portKnockingPort": 82517
+  "sshextension.portKnocking": {
+    "port": 82517
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Server object parameters:
 - **project**  _(object)_ - specify local workspace path and server root path for fast terminal open.
 - **path** _(string)_ - used for change directory after server connection.
 - **customCommands** _(array of strings)_ - specifies custom commands which will execute on session start
+- **portKnockingPort** _(number)_ - Port to knock
 
 For example:
 ```json
@@ -92,6 +93,19 @@ For example:
         },
         ...
     ]
+}
+```
+
+#### sshextension.portKnockingPort
+
+  * Type: `Number`
+  * Defaut: ``
+
+Specifies custom commands which will execute on session start.  
+For example:
+```json
+{
+  "sshextension.portKnockingPort": 82517
 }
 ```
 

--- a/adapters/config-format.js
+++ b/adapters/config-format.js
@@ -13,7 +13,7 @@ var format = function (element){
     "project": element.project,	// Used for fast button (can be undefined)
     "path": element.path, // Used for `cd` after start session (can be undefined)
     "customCommands": element.customCommands, // Used for specify commands which will execute on session start
-    "portKnockingPort": element.portKnockingPort, // Provide a port number to knock prior to SSH connection attempt
+    "portKnocking": element.portKnocking, // Provide port knocking details prior to SSH connection attempt. Will fall back to ssh host if host is undefined
   };
   return config;
 }

--- a/adapters/config-format.js
+++ b/adapters/config-format.js
@@ -13,6 +13,7 @@ var format = function (element){
     "project": element.project,	// Used for fast button (can be undefined)
     "path": element.path, // Used for `cd` after start session (can be undefined)
     "customCommands": element.customCommands, // Used for specify commands which will execute on session start
+    "portKnockingPort": element.portKnockingPort, // Provide a port number to knock prior to SSH connection attempt
   };
   return config;
 }

--- a/extension.js
+++ b/extension.js
@@ -161,7 +161,7 @@ function openSSHConnection(serverName, isFastConnection, forwardingArgs = null) 
             terminal = vscode.window.createTerminal(serverName + ((forwardingArgs != null) ? " (Forwarding)" : ""));
             // If custom commands defined send it to terminal
             terminals.push({ "name": serverName, "username": server.configuration.username, "host": server.configuration.host, "terminal": terminal, "isForwarding": (forwardingArgs != null) });
-            if (server.configuration.portKnocking.port !== undefined && server.configuration.portKnocking.port > 0) {
+            if (server.configuration.portKnocking !== undefined && server.configuration.portKnocking.port !== undefined && server.configuration.portKnocking.port > 0) {
                 var knockingHost = server.configuration.portKnocking.host !== undefined ? server.configuration.portKnocking.host : server.configuration.host;
                 terminal.sendText("curl "+knockingHost+":"+server.configuration.portKnocking.port);
             }

--- a/extension.js
+++ b/extension.js
@@ -158,6 +158,10 @@ function openSSHConnection(serverName, isFastConnection, forwardingArgs = null) 
             sshAuthorizationMethod = "byPrivateKey";
         }
         if (!hasErrors) {
+            // If custom commands defined send it to terminal
+            if (server.configuration.portKnockingPort !== undefined && server.configuration.portKnockingPort.length) {
+                terminal.sendText("curl "+server.configuration.servername+":"+server.configuration.portKnockingPort);
+            }
             terminal = vscode.window.createTerminal(serverName + ((forwardingArgs != null) ? " (Forwarding)" : ""));
             terminals.push({ "name": serverName, "username": server.configuration.username, "host": server.configuration.host, "terminal": terminal, "isForwarding": (forwardingArgs != null) });
             terminal.sendText(sshCommand);

--- a/extension.js
+++ b/extension.js
@@ -158,12 +158,12 @@ function openSSHConnection(serverName, isFastConnection, forwardingArgs = null) 
             sshAuthorizationMethod = "byPrivateKey";
         }
         if (!hasErrors) {
-            // If custom commands defined send it to terminal
-            if (server.configuration.portKnockingPort !== undefined && server.configuration.portKnockingPort.length) {
-                terminal.sendText("curl "+server.configuration.servername+":"+server.configuration.portKnockingPort);
-            }
             terminal = vscode.window.createTerminal(serverName + ((forwardingArgs != null) ? " (Forwarding)" : ""));
+            // If custom commands defined send it to terminal
             terminals.push({ "name": serverName, "username": server.configuration.username, "host": server.configuration.host, "terminal": terminal, "isForwarding": (forwardingArgs != null) });
+            if (server.configuration.portKnockingPort !== undefined && server.configuration.portKnockingPort > 0) {
+                terminal.sendText("curl "+server.configuration.host+":"+server.configuration.portKnockingPort);
+            }
             terminal.sendText(sshCommand);
             if (sshAuthorizationMethod == "byPass") {
                 terminal.sendText(server.configuration.password);

--- a/extension.js
+++ b/extension.js
@@ -161,8 +161,9 @@ function openSSHConnection(serverName, isFastConnection, forwardingArgs = null) 
             terminal = vscode.window.createTerminal(serverName + ((forwardingArgs != null) ? " (Forwarding)" : ""));
             // If custom commands defined send it to terminal
             terminals.push({ "name": serverName, "username": server.configuration.username, "host": server.configuration.host, "terminal": terminal, "isForwarding": (forwardingArgs != null) });
-            if (server.configuration.portKnockingPort !== undefined && server.configuration.portKnockingPort > 0) {
-                terminal.sendText("curl "+server.configuration.host+":"+server.configuration.portKnockingPort);
+            if (server.configuration.portKnocking.port !== undefined && server.configuration.portKnocking.port > 0) {
+                var knockingHost = server.configuration.portKnocking.host !== undefined ? server.configuration.portKnocking.host : server.configuration.host;
+                terminal.sendText("curl "+knockingHost+":"+server.configuration.portKnocking.port);
             }
             terminal.sendText(sshCommand);
             if (sshAuthorizationMethod == "byPass") {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,9 @@
                     "description": "Port to knock",
                     "required": true
                   }
+                },
+                "default": {
+                  "port" : 0
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
           "default": [],
           "description": "Specifies custom commands which will execute on session start"
         },
+        "sshextension.portKnockingPort": {
+          "type": "number"
+        },
         "sshextension.recentlyUsedForwardings": {
           "type": [
             "array"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sshextension",
   "displayName": "SSHExtension",
   "description": "Extension for SSH connections using the ftp-simple settings",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "kondratiev",
   "license": "MIT",
   "engines": {
@@ -52,9 +52,6 @@
           },
           "default": [],
           "description": "Specifies custom commands which will execute on session start"
-        },
-        "sshextension.portKnockingPort": {
-          "type": "number"
         },
         "sshextension.recentlyUsedForwardings": {
           "type": [
@@ -138,6 +135,9 @@
                 },
                 "default": [],
                 "description": "Specifies custom commands which will execute on session start"
+              },
+              "portKnockingPort": {
+                "type": "number"
               }
             }
           },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sshextension",
   "displayName": "SSHExtension",
   "description": "Extension for SSH connections using the ftp-simple settings",
-  "version": "0.5.1",
+  "version": "0.5.4",
   "publisher": "kondratiev",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sshextension",
   "displayName": "SSHExtension",
   "description": "Extension for SSH connections using the ftp-simple settings",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "publisher": "kondratiev",
   "license": "MIT",
   "engines": {
@@ -136,8 +136,21 @@
                 "default": [],
                 "description": "Specifies custom commands which will execute on session start"
               },
-              "portKnockingPort": {
-                "type": "number"
+              "portKnocking": {
+                "type": "object",
+                "description": "Specify the host and port number to knock prior to SSH connection",
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "Name of server",
+                    "required": false
+                  },
+                  "port": {
+                    "type": "number",
+                    "description": "Port to knock",
+                    "required": true
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
Hi, this is my first ever pull request and my first ever attempt at editing a VS Code extension (an application that I downloaded for the first time yesterday).
I have modified your extension to include Port Knocking. I have a particular client whose host implements port-knocking as an additional security measure. The server must be "pinged" on a given secret port number for port 22 to be opened to allow SSH connection for a short period. I usually have to perform this operation manually in a Terminal window before initiating an SSH connection. Using your extension as a basis I have been able to implement automated port-knocking so connection can be made with a single click. I hope you also think this addition would be useful to add to your extension.
Regards, Lee